### PR TITLE
Checkout repository before git commands

### DIFF
--- a/.github/workflows/stats-codestats-node-workflow.yml
+++ b/.github/workflows/stats-codestats-node-workflow.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Add `actions/checkout` step to `stats-codestats-node-workflow.yml` to resolve "fatal: not a git repository" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-84072893-8ef3-4e93-b1ff-b0ab1821190c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84072893-8ef3-4e93-b1ff-b0ab1821190c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

